### PR TITLE
Fix type of next_line in hlswebvttsink

### DIFF
--- a/subprojects/gst-plugins-bad/ext/hls/gsthlswebvttsink.c
+++ b/subprojects/gst-plugins-bad/ext/hls/gsthlswebvttsink.c
@@ -641,7 +641,7 @@ gst_hls_webvtt_sink_insert_timestamp_map (GstHlsWebvttSink * self,
   };
   GstBuffer *header_buf = NULL;
   GstMapInfo map;
-  gchar *next_line = NULL;
+  guint8 *next_line = NULL;
   gsize next_line_pos = 0;
   GString *str = NULL;
   gsize len;


### PR DESCRIPTION
This has so far been required to build on Linux. I figured might as well push it up the stream so I don't have to maintain a fork for a single line.